### PR TITLE
waffle.io Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://badge.waffle.io/pysv/pysv.org.png?label=ready&title=Ready 
+ :target: https://waffle.io/pysv/pysv.org
+ :alt: 'Stories in Ready'
 ======================================================
 Buildout und Plone Policy der http://python-verband.de
 ======================================================


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/pysv/pysv.org

This was requested by a real person (user obestwalter) on waffle.io, we're not trying to spam you.